### PR TITLE
#2988779 by bramtenhove: Disable Big Pipe for the KPI Analytics reports page

### DIFF
--- a/social_kpi_lite.routing.yml
+++ b/social_kpi_lite.routing.yml
@@ -7,3 +7,4 @@ social_kpi_lite.analytics:
     _permission: 'access kpi analytics reports'
   options:
     _admin_route: FALSE
+    _no_big_pipe: TRUE


### PR DESCRIPTION
## Problem
KPI analytics reports page has blocks which content is not loading when Big Pipe is enabled.

<img width="1285" alt="screen shot 2018-07-28 at 14 00 03" src="https://user-images.githubusercontent.com/7124754/43356431-eb90f49c-9270-11e8-8547-ed909ca0ed1f.png">

## Solution
Disable Big Pipe for the reports page.

## HTT
- [x] Enable Big Pipe and go to /admin/reports/social-kpi
- [x] Note that the graphs are not showing for (some of) the blocks
- [x] Checkout to this branch and clear your caches
- [x] Note that the graphs are showing for the blocks