### PR TITLE
DS-7199 Make module installable from installer UI

### DIFF
--- a/social_kpi_lite.installer_options.yml
+++ b/social_kpi_lite.installer_options.yml
@@ -1,0 +1,2 @@
+name: Community Health Analytics
+description: Allows Site Managers to monitor community performance using metrics about things such as number of posts and logins.


### PR DESCRIPTION
The `installer_options.yml` file allows the module to be installed with
the installer introduced in Open Social 8.0. This in turn allows the installer
to control the module without having a `social_core` module that depends
on it.