### PR TITLE
Issue #3178319 by mdeny: Show total amount of logins monthly base

### DIFF
--- a/modules/social_kpi_lite_user_login/content/block_content/social_kpi_lite_user_logins.yml
+++ b/modules/social_kpi_lite_user_login/content/block_content/social_kpi_lite_user_logins.yml
@@ -9,7 +9,7 @@ fields:
         (
           SELECT COUNT(lt.uid)
           FROM login_tracker lt
-          WHERE FROM_UNIXTIME(lt.login_timestamp, '%Y-%m') <= source.created
+          WHERE FROM_UNIXTIME(lt.login_timestamp, '%Y-%m') = source.created
         ) AS total_logins
         FROM (
             SELECT

--- a/modules/social_kpi_lite_user_login/social_kpi_lite_user_login.install
+++ b/modules/social_kpi_lite_user_login/social_kpi_lite_user_login.install
@@ -68,3 +68,17 @@ function _social_kpi_lite_user_login_delete_blocks($blocks) {
     $block_content_creator->delete();
   }
 }
+
+/**
+ * Update User logins block content with the latest changes in yml file.
+ */
+function social_kpi_lite_user_login_update_8901() {
+  $path = drupal_get_path('module', 'social_kpi_lite_user_login');
+  $block_content_path = "{$path}/content/block_content";
+  $block_id = 'social_kpi_lite_user_logins';
+  /** @var \Drupal\kpi_analytics\BlockContentCreator $block_content_creator */
+  $block_content_creator = \Drupal::service('kpi_analytics.block_content_creator');
+
+  $block_content_creator->setSource($block_content_path, $block_id);
+  $block_content_creator->update();
+}


### PR DESCRIPTION
## Problem
Total amount of logins should not be accumulated instead should be shown per month

## Solution
Show total amount of logins monthly base

## Issue tracker
https://getopensocial.atlassian.net/browse/YANG-3719
https://www.drupal.org/project/social_kpi_lite/issues/3178319

## How to test
- [ ] Total amount of logins should not be accumulated instead should be shown per month