### PR TITLE
Issue #3181010 by mdeny: Take challenges out from Groups created KPI block

### DIFF
--- a/content/block_content/social_kpi_lite_groups_created.yml
+++ b/content/block_content/social_kpi_lite_groups_created.yml
@@ -21,6 +21,8 @@ fields:
                 FROM_UNIXTIME(UNIX_TIMESTAMP(DATE_SUB(CURDATE(), INTERVAL 3 MONTH)), '%Y-%m')
             AND
                 FROM_UNIXTIME(UNIX_TIMESTAMP(CURDATE()), '%Y-%m')
+            AND
+                gfd.type NOT IN ('challenge', 'cc', 'sc')
         GROUP BY FROM_UNIXTIME(gfd.created, '%Y-%m')
     ) AS source
     GROUP BY created, count_cm, count_lu;

--- a/social_kpi_lite.install
+++ b/social_kpi_lite.install
@@ -146,3 +146,13 @@ function social_kpi_lite_update_8003() {
   ];
   _social_kpi_lite_update_blocks($blocks_update);
 }
+
+/**
+ * Update groups created block to exclude challenges.
+ */
+function social_kpi_lite_update_8004() {
+  $blocks_update = [
+    'social_kpi_lite_groups_created',
+  ];
+  _social_kpi_lite_update_blocks($blocks_update);
+}


### PR DESCRIPTION
We provided new KPI blocks for Challenges and no needed to include Challenges in Groups created KPI block anymore.

See story: https://getopensocial.atlassian.net/browse/YANG-4110
Issue: https://www.drupal.org/node/3181010